### PR TITLE
fix: fix plugin's installation with cordova >=7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cordova-plugin-sensors",
+  "version": "0.7.0",
+  "description": "This plugin gives Cordova's applications access to Android's sensors",
+  "cordova": {
+    "id": "com.fabiorogeriosj.sensors",
+    "platforms": ["android"]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QuentinRoy/cordova-plugin-sensors.git"
+  },
+  "keywords": ["ecosystem:cordova", "cordova-android", "sensors"],
+  "engines": {
+    "cordova": ">=3.4.0"
+  },
+  "author": "Fábio Rogério SJ",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/fabiorogeriosj/cordova-plugin-sensors/issues"
+  },
+  "homepage": "https://github.com/fabiorogeriosj/cordova-plugin-sensors#readme"
+}


### PR DESCRIPTION
Adds a `package.json` manifest.
Fixes #6.
**Warning**: The repository URL (in `package.json`) must be updated when merging this pull request (I had to use mine to make this working).
Adding a license is probably a good idea as well.