### PR TITLE
Fix inconsistency of the names in `package.json` and `plugin.xml`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
-        id="com.fabiorogeriosj.sensors"
+        id="cordova-plugin-sensors"
         version="0.7.0">
 
   <name>Sensors</name>


### PR DESCRIPTION
Changed the name in `plugin.xml` to follow the common naming convention for cordova plugins. Now, the name in `plugin.xml` is same as `package.json`. I have already tested my fork and it fixes #9.

Thanks